### PR TITLE
Updated for Python 3.11, type annotations, refactoring

### DIFF
--- a/color_correction.py
+++ b/color_correction.py
@@ -164,6 +164,7 @@ ap.add_argument("-o", "--output", required=False, default=False,
                 help="Image Output Path")
 ap.add_argument("-i", "--input", required=True,
                 help="path to the input image to apply color correction to")
+ap.add_argument("-d", "--debug", action="store_true", help="Debug card finder")
 args = vars(ap.parse_args())
 
 # load the reference image and input images from disk
@@ -189,6 +190,14 @@ height2, width1, channels = img1.shape
 newWidth=width0//3
 countStep=400
 goOn=False
+# First try without resizing
+raw_ = raw
+img1_ = img1
+rawCard = find_color_card(raw_, args["debug"])
+imageCard = find_color_card(img1_, args["debug"])
+if not rawCard is None and not imageCard is None:
+    goOn = True
+
 while goOn==False and newWidth<=width0:
 
     raw_ = imutils.resize(raw, newWidth)
@@ -196,8 +205,8 @@ while goOn==False and newWidth<=width0:
 
   
     print("[INFO] Finding color matching cards width "+ repr(newWidth)+"px")
-    rawCard = find_color_card(raw_, args["view"])
-    imageCard = find_color_card(img1_, args["view"])
+    rawCard = find_color_card(raw_, args["debug"])
+    imageCard = find_color_card(img1_, args["debug"])
     
     if rawCard is None or imageCard is None:
         oldW =newWidth

--- a/color_correction.py
+++ b/color_correction.py
@@ -22,14 +22,24 @@ import os.path as pathfile
 from PIL import Image
 
 
-def find_color_card(image):
+def find_color_card(image, show_aruco_results=False):
     # load the ArUCo dictionary, grab the ArUCo parameters, and
     # detect the markers in the input image
     arucoDict = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_ARUCO_ORIGINAL)
     arucoParams = cv2.aruco.DetectorParameters()
     detector = cv2.aruco.ArucoDetector(arucoDict, arucoParams)
     (corners, ids, rejected) = detector.detectMarkers(image)
-
+    if show_aruco_results:
+        outputImage = image.copy()
+        cv2.aruco.drawDetectedMarkers(outputImage, corners, ids)
+        winTitle = f"Markers."
+        cv2.imshow(winTitle, outputImage)
+        while True:
+            ch = cv2.waitKey()
+            if ch == 27:
+                break
+            print(f"ignoring key {ch}")
+        cv2.destroyWindow(winTitle)
     # try to extract the coordinates of the color correction card
     try:
         # otherwise, we've found the four ArUco markers, so we can
@@ -186,8 +196,8 @@ while goOn==False and newWidth<=width0:
 
   
     print("[INFO] Finding color matching cards width "+ repr(newWidth)+"px")
-    rawCard = find_color_card(raw_)
-    imageCard = find_color_card(img1_)
+    rawCard = find_color_card(raw_, args["view"])
+    imageCard = find_color_card(img1_, args["view"])
     
     if rawCard is None or imageCard is None:
         oldW =newWidth

--- a/color_correction.py
+++ b/color_correction.py
@@ -25,10 +25,10 @@ from PIL import Image
 def find_color_card(image):
     # load the ArUCo dictionary, grab the ArUCo parameters, and
     # detect the markers in the input image
-    arucoDict = cv2.aruco.Dictionary_get(cv2.aruco.DICT_ARUCO_ORIGINAL)
-    arucoParams = cv2.aruco.DetectorParameters_create()
-    (corners, ids, rejected) = cv2.aruco.detectMarkers(image,
-                                                       arucoDict, parameters=arucoParams)
+    arucoDict = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_ARUCO_ORIGINAL)
+    arucoParams = cv2.aruco.DetectorParameters()
+    detector = cv2.aruco.ArucoDetector(arucoDict, arucoParams)
+    (corners, ids, rejected) = detector.detectMarkers(image)
 
     # try to extract the coordinates of the color correction card
     try:

--- a/color_correction.py
+++ b/color_correction.py
@@ -85,6 +85,8 @@ def find_color_card(image : OurImageType, show_aruco_results=False) -> Optional[
 
 def _create_colormap_1channel(source : OurImageType1Channel, template : OurImageType1Channel) -> OurColormap1Channel:
     """
+    Helper function: create single-channel colormap.
+
     Return modified full image array so that the cumulative density function of
     source array matches the cumulative density function of the template.
     """
@@ -132,7 +134,8 @@ def _create_colormap_1channel(source : OurImageType1Channel, template : OurImage
             prev_index = i
     return colormap_1channel
 
-def _create_colormap(source : OurImageType, template : OurImageType) -> OurColormap:
+def create_colormap(source : OurImageType, template : OurImageType) -> OurColormap:
+    """Given a source image capture of a colorcard and a template for that colorcard return the colormap to correct the source image"""
     rv = []
     assert source.shape[-1] == template.shape[-1]
     for channel in range(source.shape[-1]):
@@ -140,24 +143,8 @@ def _create_colormap(source : OurImageType, template : OurImageType) -> OurColor
         rv.append(map)
     return rv
 
-def process_image_colors_1channel(source : OurImageType1Channel, template : OurImageType1Channel, full : OurImageType1Channel) -> OurImageType1Channel:
-    """
-    Return modified full image array so that the cumulative density function of
-    source array matches the cumulative density function of the template.
-    """
-    colormap_1channel = _create_colormap_1channel(source, template)
-    
-
-    # finally transform pixel values in full image using interpb interpolation values.
-    wid = full.shape[1]
-    hei = full.shape[0]
-    ret2 = np.zeros((hei, wid), dtype=np.uint8)
-    for i in range(0, hei):
-        for j in range(0, wid):
-            ret2[i][j] = colormap_1channel[full[i][j]]
-    return ret2
-
-def map_image_color_1channel(full_1channel : OurImageType1Channel, colormap_1channel : OurColormap1Channel) -> OurImageType1Channel:
+def _map_image_color_1channel(full_1channel : OurImageType1Channel, colormap_1channel : OurColormap1Channel) -> OurImageType1Channel:
+    """Helper function: map color for a single channel"""
     wid = full_1channel.shape[1]
     hei = full_1channel.shape[0]
     ret2 = np.zeros((hei, wid), dtype=np.uint8)
@@ -167,10 +154,11 @@ def map_image_color_1channel(full_1channel : OurImageType1Channel, colormap_1cha
     return ret2
 
 def map_image_color(fullImage : OurImageType, colormap : OurColormap) -> OurImageType:
+    """Given a source image and a colormap return a new image that has the colors mapped"""
     assert len(colormap) == fullImage.shape[-1]
     matched = np.empty(fullImage.shape, dtype=fullImage.dtype)
     for channel in range(len(colormap)):
-        matched_channel = map_image_color_1channel(fullImage[..., channel], colormap[channel])
+        matched_channel = _map_image_color_1channel(fullImage[..., channel], colormap[channel])
         matched[..., channel] = matched_channel
     return matched
     
@@ -179,142 +167,130 @@ def process_images(inputCard : OurImageType, referenceCard : OurImageType, fullI
         Return modified full image, by using histogram equalizatin on input and
          reference cards and applying that transformation on fullImage.
     """
-    colormap = _create_colormap(inputCard, referenceCard)
+    colormap = create_colormap(inputCard, referenceCard)
     rv = map_image_color(fullImage, colormap)
     return rv
 
-def process_images_old(inputCard : OurImageType, referenceCard : OurImageType, fullImage : OurImageType) -> OurImageType:
-    """
-        Return modified full image, by using histogram equalizatin on input and
-         reference cards and applying that transformation on fullImage.
-    """
-    if inputCard.ndim != referenceCard.ndim:
-        raise ValueError('Image and reference must have the same number '
-                         'of channels.')
-    matched = np.empty(fullImage.shape, dtype=fullImage.dtype)
-    for channel in range(inputCard.shape[-1]):
-        matched_channel = process_image_colors_1channel(inputCard[..., channel], referenceCard[..., channel],
-                                                    fullImage[..., channel])
-        matched[..., channel] = matched_channel
-    return matched
+def main():
+    # construct the argument parser and parse the arguments
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-r", "--reference", required=True,
+                    help="path to the input reference image")
+    ap.add_argument("-w", "--width0", required=False,
+                    help="Image Size")
+    ap.add_argument("-v", "--view", required=False, default=False, action='store_true',
+                    help="Image Preview?")
+    ap.add_argument("-o", "--output", required=False, default=False,
+                    help="Image Output Path")
+    ap.add_argument("-i", "--input", required=True,
+                    help="path to the input image to apply color correction to")
+    ap.add_argument("-d", "--debug", action="store_true", help="Debug card finder")
+    args = vars(ap.parse_args())
+
+    # load the reference image and input images from disk
+    print("[INFO] loading images...")
+    # raw = cv2.imread(args["reference"])
+    # img1 = cv2.imread(args["input"])
+    file_exists = pathfile.isfile(args["reference"])
+
+    if not file_exists:
+        print('[WARNING] Referenz File not exisits '+str(args["reference"]))
+        sys.exit()
 
 
-# construct the argument parser and parse the arguments
-ap = argparse.ArgumentParser()
-ap.add_argument("-r", "--reference", required=True,
-                help="path to the input reference image")
-ap.add_argument("-w", "--width0", required=False,
-                help="Image Size")
-ap.add_argument("-v", "--view", required=False, default=False, action='store_true',
-                help="Image Preview?")
-ap.add_argument("-o", "--output", required=False, default=False,
-                help="Image Output Path")
-ap.add_argument("-i", "--input", required=True,
-                help="path to the input image to apply color correction to")
-ap.add_argument("-d", "--debug", action="store_true", help="Debug card finder")
-args = vars(ap.parse_args())
+    raw = cast(OurImageType, cv2.imread(args["reference"]))
+    img1 = cast(OurImageType, cv2.imread(args["input"]))
 
-# load the reference image and input images from disk
-print("[INFO] loading images...")
-# raw = cv2.imread(args["reference"])
-# img1 = cv2.imread(args["input"])
-file_exists = pathfile.isfile(args["reference"])
-
-if not file_exists:
-    print('[WARNING] Referenz File not exisits '+str(args["reference"]))
-    sys.exit()
+    height, width0, channels = raw.shape
+    height2, width1, channels = img1.shape
 
 
-raw = cast(OurImageType, cv2.imread(args["reference"]))
-img1 = cast(OurImageType, cv2.imread(args["input"]))
+    # resize the reference and input images
 
-height, width0, channels = raw.shape
-height2, width1, channels = img1.shape
-
-
-# resize the reference and input images
-
-newWidth=width0//3
-countStep=400
-goOn=False
-# First try without resizing
-raw_ = raw
-img1_ = img1
-rawCard = find_color_card(raw_, args["debug"])
-imageCard = find_color_card(img1_, args["debug"])
-if not rawCard is None and not imageCard is None:
-    goOn = True
-
-while goOn==False and newWidth<=width0:
-
-    raw_ = imutils.resize(raw, newWidth)
-    img1_ = imutils.resize(img1, newWidth)
-
-  
-    print("[INFO] Finding color matching cards width "+ repr(newWidth)+"px")
+    newWidth=width0//3
+    countStep=400
+    goOn=False
+    # First try without resizing
+    raw_ = raw
+    img1_ = img1
     rawCard = find_color_card(raw_, args["debug"])
     imageCard = find_color_card(img1_, args["debug"])
+    if not rawCard is None and not imageCard is None:
+        goOn = True
+
+    while goOn==False and newWidth<=width0:
+
+        raw_ = imutils.resize(raw, newWidth)
+        img1_ = imutils.resize(img1, newWidth)
+
     
-    if rawCard is None or imageCard is None:
-        oldW =newWidth
-        newWidth +=countStep
-        print("[INFO] Could not find color with width "+ repr(oldW)+"px. Try width:"+ repr(newWidth)+"px")
-        continue
-    else:
-        goOn=True
-        break
+        print("[INFO] Finding color matching cards width "+ repr(newWidth)+"px")
+        rawCard = find_color_card(raw_, args["debug"])
+        imageCard = find_color_card(img1_, args["debug"])
+        
+        if rawCard is None or imageCard is None:
+            oldW =newWidth
+            newWidth +=countStep
+            print("[INFO] Could not find color with width "+ repr(oldW)+"px. Try width:"+ repr(newWidth)+"px")
+            continue
+        else:
+            goOn=True
+            break
 
-if(goOn is False):
-    print("[WARNING] Could not find color matching cards in both images. Try a highter/better Resolution")
-       
-    sys.exit()
-assert not rawCard is None
-assert not imageCard is None
-if args['view']:
-        cv2.imshow("Reference", raw_)
-        cv2.imshow("Input", img1_)
-# show the color matching card in the reference image and input image,
-# respectively
-if args['view']:
-    cv2.imshow("Reference Color Card", rawCard)
-    cv2.imshow("Input Color Card", imageCard)
-# apply histogram matching from the color matching card in the
-# reference image to the color matching card in the input image
-print("[INFO] matching images...")
+    if(goOn is False):
+        print("[WARNING] Could not find color matching cards in both images. Try a highter/better Resolution")
+        
+        sys.exit()
+    assert not rawCard is None
+    assert not imageCard is None
+    if args['view']:
+            cv2.imshow("Reference", raw_)
+            cv2.imshow("Input", img1_)
+    # show the color matching card in the reference image and input image,
+    # respectively
+    if args['view']:
+        cv2.imshow("Reference Color Card", rawCard)
+        cv2.imshow("Input Color Card", imageCard)
+    # apply histogram matching from the color matching card in the
+    # reference image to the color matching card in the input image
+    print("[INFO] matching images...")
 
-# imageCard2 = exposure.match_histograms(img1, ref,
-# inputCard = exposure.match_histograms(inputCard, referenceCard, multichannel=True)
+    # imageCard2 = exposure.match_histograms(img1, ref,
+    # inputCard = exposure.match_histograms(inputCard, referenceCard, multichannel=True)
 
-if args["width0"]:
-    width=int(args["width0"])
-    if width>1:    
-        print('resize Final: '+repr(width))
-        img1 = imutils.resize(img1, width)
+    if args["width0"]:
+        width=int(args["width0"])
+        if width>1:    
+            print('resize Final: '+repr(width))
+            img1 = imutils.resize(img1, width)
 
-result2 = process_images(imageCard, rawCard, img1)
-
-
-
-
-# show our input color matching card after histogram matching
-#cv2.imshow("Input Color Card After Matching", inputCard)
+    result2 = process_images(imageCard, rawCard, img1)
 
 
-if args['view']:
-    cv2.imshow("Output image", result2)
 
-if args['output']:
-    file_ok = exists(args['output'].lower().endswith(('.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.gif')))
 
-    if file_ok:
-        cv2.imwrite(args['output'], result2)
-        print("[SUCCESSUL] Your Image was written to: "+args['output']+"")
-    else:
-        print("[WARNING] Sorry, But this is no valid Image Name "+args['output']+"\nPlease Change Parameter!")
+    # show our input color matching card after histogram matching
+    #cv2.imshow("Input Color Card After Matching", inputCard)
 
-if args['view']:
-    cv2.waitKey(0)
 
-if not args['view']:
-    if not args['output']:
-        print('[EMPTY] You Need at least one Paramter "--view" or "--output".')
+    if args['view']:
+        cv2.imshow("Output image", result2)
+
+    if args['output']:
+        file_ok = exists(args['output'].lower().endswith(('.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.gif')))
+
+        if file_ok:
+            cv2.imwrite(args['output'], result2)
+            print("[SUCCESSUL] Your Image was written to: "+args['output']+"")
+        else:
+            print("[WARNING] Sorry, But this is no valid Image Name "+args['output']+"\nPlease Change Parameter!")
+
+    if args['view']:
+        cv2.waitKey(0)
+
+    if not args['view']:
+        if not args['output']:
+            print('[EMPTY] You Need at least one Paramter "--view" or "--output".')
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 
-#Tested with python 3.8.10
+#Tested with python 3.11.6
 imutils==0.5.4
-numpy==1.23
-opencv-contrib-python>=4.6.0
-Pillow==9.2
-scikit-image==0.18.1
-scipy==1.9.1
+numpy==1.26.4
+opencv-contrib-python==4.9.0.80
+pillow==10.2.0
+scikit-image==0.22.0
+scipy==1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ opencv-contrib-python==4.9.0.80
 pillow==10.2.0
 scikit-image==0.22.0
 scipy==1.12.0
+matplotlib==3.8.2


### PR DESCRIPTION
I'm not sure if you're interested in my changes (I can imagine that you're not, and I won't be sad if you won't pick them up:-), but I thought I'd share them with you anyway. It's become a bit more than I initially envisioned...

- Updated Python packages to Python 3.11, including API changes for some
- Added some type annotations so editing in vscode becomes quite a bit easier with hints and such
- Refactored so there are now distinct steps to 
  - create the colormapping curves, and 
  - apply those curves to the source image
- Added a debug option to optionally show the aruco finder results and the mapping curves

The next thing I'm going to do is probably another step of refactoring, to turn the whole thing into a class so that you can use distinct steps of (1) creating the colormaps and (2) mapping the images. This should allow reuse of a single colormap for multiple images. But that's for later.